### PR TITLE
fix cluster params to pass as arrays instead of strings

### DIFF
--- a/lib/puppet/provider/mscs_cluster/mscs_cluster.rb
+++ b/lib/puppet/provider/mscs_cluster/mscs_cluster.rb
@@ -8,22 +8,27 @@ Puppet::Type.type(:mscs_cluster).provide(:mscs_cluster) do
   def create
     cluster_config={
       :ClusterName     => @resource[:name],
-      :NodeNames       => @resource[:nodenames],
-      :IPAddresses     => @resource[:ipaddresses],
-      :SubnetMasks     => @resource[:subnetmasks],
+      :NodeNames       => @resource[:nodenames].to_a,
+      :IPAddresses     => @resource[:ipaddresses].to_a,
+      :SubnetMasks     => @resource[:subnetmasks].to_a,
       }
-    Mscs::Cluster.create(server, cluster_config)
+      
+    kerb_name="nyise\\#{@resource[:nodenames].to_a.first}"
+    Mscs::Cluster.create(@resource[:nodenames].first, cluster_config,kerb_name)
   end
 
   def destroy
-    cluster_handle=Mscs::Cluster.open('Cluster',@resource[:clustername])
+    cluster_handle=Mscs::Cluster.open('Cluster',@resource[:name])
     removal=Mscs::Cluster.destroy(cluster_handle,@resource[:name])
   end
 
   def exists?
-    cluster_handle=Mscs::Cluster.open('Cluster',@resource[:clustername])
-    clusterquery=Mscs::Cluster.enumerate('Cluster', cluster_handle, 1)
-    clusterquery.include? @resource[:nodenames]
+    #we use the server name here, and not the virtual name,
+    #because it may not be available yet...
+    cluster_handle=Mscs::Cluster.open('Cluster',@resource[:nodenames].first)
+    cluster_handle == 0 ? (return false) : (return true)
+    #clusterquery=Mscs::Cluster.enumerate('Cluster', cluster_handle, 1)
+    #clusterquery.include? @resource[:nodenames]
   end
 
 end

--- a/lib/puppet/type/mscs_cluster.rb
+++ b/lib/puppet/type/mscs_cluster.rb
@@ -14,22 +14,22 @@ Puppet::Type.newtype(:mscs_cluster) do
     end
 
   end
-
-  newparam(:nodenames, :parent => Puppet::MscsProperty) do
+  
+  newparam(:nodenames, :array_matching => :all) do
     desc "The name of the cluster"
     validate do |value|
       raise Puppet::Error, "Name must not be empty" if value.empty?
     end
   end
 
-  newparam(:ipaddresses, :parent => Puppet::MscsProperty) do
+  newparam(:ipaddresses, :array_matching => :all) do
     desc "The group on the cluster"
     validate do |value|
       raise Puppet::Error, "Name must not be empty" if value.empty?
     end
   end
 
-  newparam(:subnetmasks, :parent => Puppet::MscsProperty) do
+  newparam(:subnetmasks, :array_matching => :all) do
     desc "The subnetmasks to be be assigned to the cluster ips"
     validate do |value|
       raise Puppet::Error, "Name must not be empty" if value.empty?

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,51 +1,28 @@
-  mscs_cluster {'cc-git01a.office.iseoptions.com':
-    nodenames => 'cc-git01',
-    ipaddresses => '30.3.4.43',
-    subnetmasks => '255.255.255.0',
+  mscs_cluster {'cc-git01x':
+    nodenames   => ['cc-git01'],
+    ipaddresses => ['30.3.4.42'],
+    subnetmasks => ['255.255.255.0'],
+    ensure      => present,
   }
 
-  mscs_node {'cc-git01':
-    clustername => 'cc-git01a',
-    require  => Mscs_node['cc-git01a.office.iseoptions.com'],
-  }
+  #mscs_node {'cc-git01':
+  #  clustername => 'cc-git01a',
+  #  require  => Mscs_node['cc-git01a.office.iseoptions.com'],
+  #}
 
   mscs_group {['booya','kasha']:
-    clustername => 'cc-git01a',
+    clustername => 'cc-git01x',
     ensure   => present,
-    require  => Mscs_node['cc-git01']
+    require  => Mscs_cluster['cc-git01x']
   }
 
   mscs_resource {'myresourcex':
-    clustername => 'cc-git01a',
+    clustername => 'cc-git01x',
     resourcetype => 'ipaddress',
     clustergroup => 'booya',
     ipaddress => '30.3.4.44',
     subnetmask => '255.255.255.0',
-    network => 'C_MGMT-304',
+    network => 'Cluster Network 1',
     ensure   => present,
     require  => Mscs_group['booya'],
   }
-
-# the logic for the following should perform the following
-# When ensure = > present
-# 1. validate the clustername.  if not valid cluster raise error (clusters should be created via mscs type)
-# 2. validate the clustergroup. if not valid clusgrp raise error (clustgrp should be created via mscs_group type)
-# 3a. if 1,2 true, and resource is absent, then resource will be created (raise error on creation failure)
-#   - set attributes on newly created object
-#   - raise errors if attributes can't be set
-# 3b. if 1,2 true, and resource is present, then attribute hash table needs to be done on endpoint
-#   - compare values in actual hash table vs puppet type 
-#   - set any mismatches
-#   - raise errors if attributes can't be set
-
-# if ensure = > absent
-# 4. if 1,2 true and resource is absent do nothing
-# 5. if 1,2 true and resource is present 
-#   - call cluster resource delete
-#   - raise error if deletion fails
-
-#mscs_resource will not create a cluster
-#mscs_resource will not create a node
-#mscs_resource will not create a group
-#mscs_resource will only manage puppet supported priv properties (additional can only be added through code upgrades)
-#valid values for resourcetype are checking at type level and will validate attribs accordingly


### PR DESCRIPTION
fixed receiving arrays using .to_a in provider on cluster_config
fixed array on type using :array_matching =>  all
cleaned up init.pp

fix exists? to use first node name, to prevent dns availability
on new virtual name from causing failure
